### PR TITLE
Fix deploy on using base in config (@dsturm)

### DIFF
--- a/src/PHPloy.php
+++ b/src/PHPloy.php
@@ -699,6 +699,42 @@ class PHPloy
     }
 
     /**
+     * Filter files form base path.
+     *
+     * @param array $files Array of files which needed to be filtered
+     *
+     * @return array
+     */
+    private function filterBasePathFiles(array $files) : array {
+        if (!$this->base) {
+            return $files;
+        }
+
+        $base = $this->base;
+
+        
+        return array_values(
+            array_filter(
+                $files,
+                function($file) use ($base) {
+                    return preg_match('/^'.preg_quote($base, '/').'/', $file);
+                }
+            )
+        );
+    }
+
+    /**
+     * Remove bath path from file / path
+     *
+     * @param string $file
+     *
+     * @return string
+     */
+    private function removeBasePath(string $file) : string {
+        return $this->base ? preg_replace('/^'.preg_quote($this->base, '/').'/', '', $file) : $file;
+    }
+
+    /**
      * Filter included files.
      *
      * @param array $files        Array of files which needed to be filtered
@@ -987,6 +1023,9 @@ class PHPloy
 
         $filesToUpload = array_merge($filteredFilesToUpload['files'], $filteredFilesToInclude);
         $filesToDelete = $filteredFilesToDelete['files'];
+
+        $filesToUpload = $this->filterBasePathFiles($filesToUpload);
+        $filesToDelete = $this->filterBasePathFiles($filesToDelete);
 
         $filesToSkip = array_merge($filteredFilesToUpload['filesToSkip'], $filteredFilesToDelete['filesToSkip']);
 

--- a/src/PHPloy.php
+++ b/src/PHPloy.php
@@ -591,7 +591,7 @@ class PHPloy
             $this->filesToExclude[$name][] = $this->iniFileName;
 
             if (!empty($options['base'])) {
-                $this->base = $options['base'].(substr($options['base'], -1) !== '/' ? '/' : '');
+                $this->base = rtrim($options['base'], '/').'/';
             }
 
             if (!empty($options['exclude'])) {

--- a/src/PHPloy.php
+++ b/src/PHPloy.php
@@ -1081,8 +1081,11 @@ class PHPloy
                     $file = $this->currentSubmoduleName.'/'.$file;
                 }
 
+                // Remove base path, if set.
+                $fileBaseless = $this->removeBasePath($file);
+
                 // Make sure the folder exists in the FTP server.
-                $dir = explode('/', dirname($file));
+                $dir = explode('/', dirname($fileBaseless));
                 $path = '';
                 $ret = true;
 
@@ -1114,12 +1117,12 @@ class PHPloy
                 }
 
                 // If base is set, remove it from filename
-                $remoteFile = $this->base ? preg_replace('/^'.preg_quote($this->base, '/').'/', '', $file) : $file;
+                $remoteFile = $fileBaseless;
 
                 $uploaded = $this->connection->put($remoteFile, $data);
 
                 if (!$uploaded) {
-                    $this->cli->error(" ! Failed to upload {$file}.");
+                    $this->cli->error(" ! Failed to upload {$fileBaseless}.");
 
                     if (!$this->connection) {
                         $this->cli->info(' * Connection lost, trying to reconnect...');
@@ -1131,7 +1134,7 @@ class PHPloy
                 $this->deploymentSize += filesize($this->repo.'/'.($this->currentSubmoduleName ? str_replace($this->currentSubmoduleName.'/', '', $file) : $file));
                 $total = count($filesToUpload);
                 $fileNo = str_pad(++$fileNo, strlen($total), ' ', STR_PAD_LEFT);
-                $this->cli->lightGreen(" ^ $fileNo of $total <white>{$file}");
+                $this->cli->lightGreen(" ^ $fileNo of $total <white>{$fileBaseless}");
             }
         }
 

--- a/src/PHPloy.php
+++ b/src/PHPloy.php
@@ -495,20 +495,19 @@ class PHPloy
      * @param bool $overwriteArrayValues true to overwrite (not merge) values which are arrays, false otherwise
      * @return array
      */
-    private function mergeOptions($existing, $new, $overwriteArrayValues = false) {
+    private function mergeOptions($existing, $new, $overwriteArrayValues = false)
+    {
         $merged = $existing;
-        foreach($existing as $k => $v) {
+        foreach ($existing as $k => $v) {
             if (!$overwriteArrayValues && is_array($v) && isset($new[$k]) && is_array($new[$k])) {
                 $merged[$k] = array_merge($v, $new[$k]);
-            }
-            else if (isset($new[$k])) {
+            } elseif (isset($new[$k])) {
                 $merged[$k] = $new[$k];
-            }
-            else {
+            } else {
                 $merged[$k] = $v;
             }
         }
-        foreach($new as $k => $v) {
+        foreach ($new as $k => $v) {
             if (!is_array($v)) {
                 $merged[$k] = $v;
             }
@@ -705,7 +704,8 @@ class PHPloy
      *
      * @return array
      */
-    private function filterBasePathFiles(array $files) : array {
+    private function filterBasePathFiles(array $files) : array
+    {
         if (!$this->base) {
             return $files;
         }
@@ -716,7 +716,7 @@ class PHPloy
         return array_values(
             array_filter(
                 $files,
-                function($file) use ($base) {
+                function ($file) use ($base) {
                     return preg_match('/^'.preg_quote($base, '/').'/', $file);
                 }
             )
@@ -730,7 +730,8 @@ class PHPloy
      *
      * @return string
      */
-    private function removeBasePath(string $file) : string {
+    private function removeBasePath(string $file) : string
+    {
         return $this->base ? preg_replace('/^'.preg_quote($this->base, '/').'/', '', $file) : $file;
     }
 
@@ -1268,7 +1269,10 @@ class PHPloy
                         'name' => $line[1],
                         'path' => $repo.'/'.$line[1],
                     ];
-                    $this->cli->out(sprintf('   Found submodule %s. %s', $line[1], $this->scanSubSubmodules ? PHP_EOL.'      Scanning for sub-submodules...' : null
+                    $this->cli->out(sprintf(
+                        '   Found submodule %s. %s',
+                        $line[1],
+                        $this->scanSubSubmodules ? PHP_EOL.'      Scanning for sub-submodules...' : null
                     ));
                 }
 


### PR DESCRIPTION
Merge of an [opened PR](https://github.com/banago/PHPloy/pull/363) on the original [banago/phploy](https://github.com/banago/PHPloy) repository.

@dsturm wrote:
> This PR should fix [an issue](https://github.com/banago/PHPloy/issues/292#issuecomment-382788208), where the project root is used instead of the configurated base path. Also, it adds a filter which removes files above the base path from deployment queue. Further the "cleaned" file path is used in CLI output.
